### PR TITLE
Issue/podspec swift version

### DIFF
--- a/WordPressFlux.podspec
+++ b/WordPressFlux.podspec
@@ -5,13 +5,14 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
                        WordPressFlux is a Flux-inspired data flow architecture.
                        DESC
+  s.author           = { "WordPress" => "mobile@automattic.com" }
   s.homepage         = "https://github.com/wordpress-mobile/WordPressFlux-iOS"
   s.license          = { :type => 'GPLv2', :file => 'LICENSE' }
-  s.author           = { "WordPress" => "mobile@automattic.com" }
+  s.platform     = :ios, '10.0'
+  s.requires_arc = true
   s.social_media_url = "https://twitter.com/WordPressiOS"
   s.source           = { :git => "https://github.com/wordpress-mobile/WordPressFlux-iOS.git", :tag => s.version.to_s }
-  s.platform     = :ios, '10.0'
-  s.requires_arc = true 
   s.source_files = 'WordPressFlux/*.h', 'WordPressFlux/Sources/*.swift'
-
+  s.swift_version = '4.2'
+  
 end

--- a/WordPressFlux.podspec
+++ b/WordPressFlux.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version          = "1.0.0"
   s.summary          = "WordPressFlux is a Flux-inspired data flow architecture."
   s.description      = <<-DESC
-                       WordPressFlux is a Flux-inspired data flow architecture.
+                       WordPressFlux is a Flux-inspired data flow architecture. See README for details.
                        DESC
   s.author           = { "WordPress" => "mobile@automattic.com" }
   s.homepage         = "https://github.com/wordpress-mobile/WordPressFlux-iOS"


### PR DESCRIPTION
This PR is just a couple of minor tweaks to silence linter warnings.

To test: 
- Check out the branch
- Run `pod spec lint WordPressFlux.podspec`
- Confirm there are no warnings.

@jklausa, game for one more? 