### PR TITLE
Remove warnings for deprecated methods

### DIFF
--- a/WordPressFlux.podspec
+++ b/WordPressFlux.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WordPressFlux"
-  s.version          = "1.0.0"
+  s.version          = "1.0.1-beta.1"
   s.summary          = "WordPressFlux is a Flux-inspired data flow architecture."
   s.description      = <<-DESC
                        WordPressFlux is a Flux-inspired data flow architecture. See README for details.

--- a/WordPressFlux/Sources/Dispatcher.swift
+++ b/WordPressFlux/Sources/Dispatcher.swift
@@ -3,8 +3,8 @@
 public struct DispatchToken: Hashable, Equatable {
     private let uuid = UUID()
 
-    public var hashValue: Int {
-        return uuid.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
     }
 
     public static func ==(lhs: DispatchToken, rhs: DispatchToken) -> Bool {

--- a/WordPressFlux/Sources/QueryStore.swift
+++ b/WordPressFlux/Sources/QueryStore.swift
@@ -43,7 +43,7 @@ open class QueryStore<State, Query>: StatefulStore<State>, Unsubscribable {
     /// Unregisters the query associated with the given Receipt.
     ///
     public func unsubscribe(receipt: Receipt) {
-        guard let index = activeQueryReferences.index(where: { $0.token == receipt.token }) else {
+        guard let index = activeQueryReferences.firstIndex(where: { $0.token == receipt.token }) else {
             assertionFailure("Stopping a query that's not active")
             return
         }


### PR DESCRIPTION
This PR just removes 2 warnings about deprecated methods.
• `index(where:` replaced by `firstIndex(where:`
• `var hashValue: Int` replaced by:
```
func hash(into hasher: inout Hasher) {
        hasher.combine(uuid)
    }
```