### PR TITLE
Associatedtype Payload for Observable Protocol

### DIFF
--- a/WordPressFlux.podspec
+++ b/WordPressFlux.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WordPressFlux"
-  s.version          = "1.0.1-beta.1"
+  s.version          = "1.1.0-beta.1"
   s.summary          = "WordPressFlux is a Flux-inspired data flow architecture."
   s.description      = <<-DESC
                        WordPressFlux is a Flux-inspired data flow architecture. See README for details.

--- a/WordPressFlux/Sources/Observable.swift
+++ b/WordPressFlux/Sources/Observable.swift
@@ -13,9 +13,10 @@
 ///
 ///
 public protocol Observable {
+    associatedtype Payload
     /// The Dispatcher to keep track of all observers.
     ///
-    var changeDispatcher: Dispatcher<Void> { get }
+    var changeDispatcher: Dispatcher<Payload> { get }
 
     /// Registers a new observer.
     ///
@@ -23,14 +24,21 @@ public protocol Observable {
     /// The observer should keep a copy of the returned Receipt for as long as
     /// it desires to receive change notifications.
     ///
-    func onChange(_ handler: @escaping () -> Void) -> Receipt
+    func onChange(_ handler: @escaping (Payload) -> Void) -> Receipt
 }
 
 public extension Observable {
-    func onChange(_ handler: @escaping () -> Void) -> Receipt {
+    func onChange(_ handler: @escaping (Payload) -> Void) -> Receipt {
         return changeDispatcher.subscribe(handler)
     }
 
+    /// Notifies all registered observers of a change for a specific payload.
+    func emitChange(for payload: Payload) {
+        changeDispatcher.dispatch(payload)
+    }
+}
+
+public extension Observable where Payload == Void {
     /// Notifies all registered observers of a change.
     func emitChange() {
         changeDispatcher.dispatch()

--- a/WordPressFluxTests/WordPressFluxTests.swift
+++ b/WordPressFluxTests/WordPressFluxTests.swift
@@ -158,4 +158,50 @@ class WordPressFluxTests: XCTestCase {
         XCTAssertEqual(store.activeQueries.count, 1, "Store should have one active query")
         XCTAssertEqual(store.queriesChangedCount, 1, "Store should have processed one queriesChanged event")
     }
+    
+    func testObservable() {
+        class TestViewModel: Observable {
+            var changeDispatcher: Dispatcher<Void> = Dispatcher()
+            
+            private (set) var id: Int = 0 {
+                didSet {
+                    emitChange()
+                }
+            }
+            
+            func test() {
+                id = 1
+            }
+        }
+        
+        let viewModel = TestViewModel()
+        var receipts = [Receipt]()
+        receipts.append(viewModel.onChange {
+            XCTAssertEqual(viewModel.id, 1, "view model id should be 1 after `emitChange`")
+        })
+        viewModel.test()
+    }
+    
+    func testObservableWithPayload() {
+        class TestViewModel: Observable {
+            var changeDispatcher: Dispatcher<Int> = Dispatcher()
+            
+            private var id: Int = 0 {
+                didSet {
+                    emitChange(for: id)
+                }
+            }
+            
+            func test() {
+                id = 1
+            }
+        }
+        
+        let viewModel = TestViewModel()
+        var receipts = [Receipt]()
+        receipts.append(viewModel.onChange { id in
+            XCTAssertEqual(id, 1, "view model id should be 1 after `emitChange` with a specific payload")
+        })
+        viewModel.test()
+    }
 }


### PR DESCRIPTION
This PR uses an `associatedtype` to set a generic Payload with the protocol Dispatcher.
Set a generic Payload allows me to:
• Keep the compatibility with the current implementation if its value is _Void_
```
viewModel.onChange {
...
}
```
• Get the Payload as closure argument
```
viewModel.onChange { payload in
...
}
```